### PR TITLE
Fixing build errors. 

### DIFF
--- a/Sources/HappyToast/HappyToast.swift
+++ b/Sources/HappyToast/HappyToast.swift
@@ -1,7 +1,7 @@
 #if !os(macOS)
 import UIKit
 
-enum ToastType {
+public enum ToastType {
     case neutral
     case success
     case warning
@@ -50,7 +50,8 @@ extension UIView {
     public func showToast(message: String, type: ToastType = .neutral) {
         let toast = Toast.shared
         toast.label.text = message
-        toast.backgroundColor = colorFor(type: type)
+        toast.backgroundColor = toast.colorFor(type: type)
+        
         if let nav = findNavBar() {
             toast.frame = nav.frame
             insertSubview(toast, belowSubview: nav)


### PR DESCRIPTION
Xcode 11.2.1, Swift 5

Upon running, I was met with the following errors:
- Method cannot be declared public because its parameter is an internal type.
- Enum case "neutral" is internal and cannot be referenced from a default argument value. 
- Use of unresolved identifier `colorFor` 